### PR TITLE
automate updating of requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ function/my_private_package-1.3.1-py3-none-any.whl
 python-dotenv==0.19.2
 ```
 
+The file update_requirements.sh is a script to automatically sync the requirements.txt files with the poetry environement. Modify the directoriy names with cognite functions from `example_function1` and `example_function2` to fit your directory names and run the shell script:
+
+```shell
+sh update_requirements.sh
+
+```
+
 **Private Dependencies**: You can include private packages (dependencies which are not published
 to PyPi.org) by building and adding the wheel to the function folder. You can build a wheel
 by running the following command inside your private package root directory

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for FUNCTION in example_function1 example_function2
+do
+	poetry export -f requirements.txt --without-hashes > $FUNCTION/requirements.txt
+done


### PR DESCRIPTION
Adds a script to simplify the update of requirements.txt files

This is a suggestion for making it easier for users of the template to update requirements.txt files. This is something I have found useful and therefore wanted to add it to the template so others can benefit from this.

Let me know if you have any suggestions for further improving this.

Timeline: not urgent