### PR TITLE
Add runtime to function parameters

### DIFF
--- a/.github/workflows/deploy-push-master.yaml
+++ b/.github/workflows/deploy-push-master.yaml
@@ -65,6 +65,7 @@ jobs:
           cdf_project: forge-sandbox
           cdf_cluster: greenfield  # or api, westeurope-1, etc.
           data_set_id: "4972094093286445"
+          runtime: py39
           # Parameters we can read/extract automatically:
           function_folder: ${{ matrix.function }}
           function_external_id: ${{ matrix.function }}-${{ steps.extract_name.outputs.name }}

--- a/.github/workflows/deploy-push-test.yaml
+++ b/.github/workflows/deploy-push-test.yaml
@@ -65,6 +65,7 @@ jobs:
           cdf_project: az-forge-sandbox
           cdf_cluster: bluefield  # or api, westeurope-1, etc.
           data_set_id: "7289494538225428"
+          runtime: py39
           # Parameters we can read/extract automatically:
           function_folder: ${{ matrix.function }}
           function_external_id: ${{ matrix.function }}-${{ steps.extract_name.outputs.name }}


### PR DESCRIPTION
Update template with an example of how to specify the python version. It could of course be specified per function, but I still added it in the "most likely hardcoded" section.