### PR TITLE
Update deploy-functions.yaml

### DIFF
--- a/.github/workflows/deploy-functions.yaml
+++ b/.github/workflows/deploy-functions.yaml
@@ -96,8 +96,8 @@ jobs:
           cdf_project: ${{ steps.extract_params.outputs.cdf_project }}
           cdf_cluster: ${{ steps.extract_params.outputs.cdf_cluster }}
           data_set_id: ${{ steps.extract_params.outputs.data_set_id }}
-          schedules_tenant_id: ${{ steps.extract_params.outputs.tenant_id }}
-          deployment_tenant_id: ${{ steps.extract_params.outputs.tenant_id }}
+          schedules_tenant_id: ${{ steps.extract_params.outputs.schedules_tenant_id }}
+          deployment_tenant_id: ${{ steps.extract_params.outputs.deployment_tenant_id }}
           common_folder: ${{ steps.extract_params.outputs.common_folder }}
           function_deploy_timeout: ${{ steps.extract_params.outputs.function_deploy_timeout }}
           post_deploy_cleanup: ${{ steps.extract_params.outputs.post_deploy_cleanup }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Cognite function template [1.3.0]
+## Cognite function template [1.4.0]
 
 ### NB: Due to how we have to deploy code, [running locally](https://github.com/cognitedata/deploy-functions-oidc#run-code-locally) requires an extra step. Please read it!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "deploy-functions-oidc-template"
-version = "1.3.0"
+version = "1.4.0"
 description = "Cognite Functions template for OIDC projects"
 authors = ["hakon.treider@cognite.com"]
 


### PR DESCRIPTION
Error message says `deployment_tenant_id` is missing, but you @wesselj had changed it to `tenant_id`. This reverses the change.
```
pydantic.error_wrappers.ValidationError: 1 validation error for DeployCredentials
deployment_tenant_id
  field required (type=value_error.missing)
```