### PR TITLE
Update actions/checkout

### DIFF
--- a/.github/workflows/deploy-functions.yaml
+++ b/.github/workflows/deploy-functions.yaml
@@ -26,8 +26,10 @@ jobs:
     environment: ${{ matrix.environment }}
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v4
         if: ${{ contains(needs.generate-matrix.outputs.deploy_folders, matrix.function) }}
+        with:  # we deploy based on a diff vs. prev commit, thus we need history:
+          fetch-depth: 0
 
       - name: Extract branch name
         if: ${{ contains(needs.generate-matrix.outputs.deploy_folders, matrix.function) }}


### PR DESCRIPTION
Due to the f... bot automerging changes to Github workflows, the deploy repo starts failing as the change from v3 to v4 doesn't fetch the history (only latest commit).

...and since we diff versus last on main branch to find which functions to deploy, this fails.

I hate that bot.