### PR TITLE
Display warning of no unit tests defined without creating error in PR

### DIFF
--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -42,8 +42,12 @@ jobs:
         if: steps.cached-poetry-venv.outputs.cache-hit != 'true'
 
       - name: Test code using unit tests
-        run: PYTHONPATH=${{ matrix.function }} poetry run pytest tests/${{ matrix.function }} -m "unit" --suppress-no-test-exit-code
-
+        run: |
+            if [ -d "tests/${{ matrix.function }}" ]; then
+              PYTHONPATH=${{ matrix.function }} poetry run pytest "tests/${{ matrix.function }}" -m "unit"
+            else
+              echo "No tests to run for ${{ matrix.function }}"
+            fi
       # If your repo decides to rename 'common', remember to update below:
       - name: Test util/shared code
         run: poetry run pytest tests/common -m "unit" --suppress-no-test-exit-code

--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -46,7 +46,7 @@ jobs:
             if [ -d "tests/${{ matrix.function }}" ]; then
               PYTHONPATH=${{ matrix.function }} poetry run pytest "tests/${{ matrix.function }}" -m "unit"
             else
-              echo "No tests to run for ${{ matrix.function }}"
+              echo "::warning file=$(basename $0),line=$LINENO::No tests to run for ${{ matrix.function }}"
             fi
       # If your repo decides to rename 'common', remember to update below:
       - name: Test util/shared code

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Cognite function template [1.6.0]
+## Cognite function template [1.7.0]
 
 ### NB: Due to how we have to deploy code, [running locally](https://github.com/cognitedata/deploy-functions-oidc#run-code-locally) requires an extra step. Please read it!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "deploy-functions-oidc-template"
-version = "1.6.0"
+version = "1.7.0"
 description = "Cognite Functions template for OIDC projects"
 authors = ["hakon.treider@cognite.com"]
 


### PR DESCRIPTION
Prevent PR tests from displaying an error when no unit tests are defined for a given function, which can occur.

The change consists of a conditional check to verify the existence of the test directory for the function before attempting to run tests. If the directory does not exist, the workflow will emit a formal GitHub Actions warning and proceed without executing the nonexistent tests. 

![image](https://github.com/cognitedata/deploy-functions-oidc/assets/19209618/1c70ea3a-efc8-412a-ac3a-b13de40b2c56)

This warning will be also be visible in the Actions log and will serve as a clear indicator of the skipped test execution.

![image](https://github.com/cognitedata/deploy-functions-oidc/assets/19209618/51e9c1cd-2ff8-474d-b2f4-ea9d5ae60594)

This change aims to strike a balance between encouraging best practices, writing unit tests in this case, and offering flexibility to developers who may have reasons for not including tests at certain stages of their workflow. It respects the diversity of usage scenarios for the template, from rapid prototyping to production functions, by providing clear feedback when tests are skipped, without hindering the deployment process.
